### PR TITLE
Remove unnecessary dev dependency on Skulpt

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "webpack": "^1.13.1"
   },
   "devDependencies": {
-    "skulpt": "git+https://github.com/codecombat/skulpt.git",
     "chai": "^3.5.0",
     "mocha": "^3.0.2"
   }


### PR DESCRIPTION
`codecombat/skulpt` doesn't exist. Thus an error is thrown with `npm i`.

Should this instead point at [`skulpt/skulpt`](https://github.com/skulpt/skulpt)?