### PR TITLE
fix loaction error

### DIFF
--- a/lib/skulpt.js
+++ b/lib/skulpt.js
@@ -9853,7 +9853,7 @@ Sk.nameForToken = function(v) {
 	return '???:' + v;
 };
 
-//Sk.python3 = true;
+Sk.python3 = true;
 Sk.Parser = Parser;
 Sk.builtin.str.prototype.valueOf = function() { return this.v; };
 Sk.builtin.str.prototype.toString = function() { return this.v; };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "webpack": "^1.13.1"
   },
   "devDependencies": {
-    "skulpt": "git+https://github.com/codecombat/skulpt.git",
     "chai": "^3.5.0",
     "mocha": "^3.0.2"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,13 @@ function rangeToLoc(x, offsets) {
 
 function locToRange(line, col, offsets) {
 	var loff = 0;
-	if ( line >= 2 && (line-2) < offsets.length ) loff = offsets[line-2];
+	if ( line >= 2 ) {
+		if ( line - 2 < offsets.length ) {
+			loff = offsets[line-2];
+		} else if ( offsets.length > 0 ) {
+			loff = offsets[offsets.length-1];
+		}
+	}
 	return loff + col;
 }
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -1034,7 +1034,7 @@ function transformNum(node, ctx) {
 function transformPrint(node, ctx) {
 	return {
 		type: "CallExpression",
-		callee: makeVariableName("console.log"),
+		callee: makeVariableName("print"),
 		arguments: transform(node.values, ctx)
 	};
 }


### PR DESCRIPTION
If the python code does not end with a empty line, the last syntax element produced by `Sk.parse` will hold `lineno=line_of_code + 1` which makes `lineno` larger than `offsets` in funciton `locToRange` and return a range 0, finally the last syntax element's loaction will be wrong.
