### PR TITLE
fix loaction

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,13 @@ function rangeToLoc(x, offsets) {
 
 function locToRange(line, col, offsets) {
 	var loff = 0;
-	if ( line >= 2 && (line-2) < offsets.length ) loff = offsets[line-2];
+	if ( line >= 2 ) {
+		if ( line - 2 < offsets.length ) {
+			loff = offsets[line-2];
+		} else if ( offsets.length > 0 ) {
+			loff = offsets[offsets.length-1];
+		}
+	}
 	return loff + col;
 }
 


### PR DESCRIPTION
If the python code does not end with a empty line, the last syntax element produced by `Sk.parse` will hold `lineno=line_of_code + 1` which makes `lineno` larger than `offsets` in funciton `locToRange` and return a range 0, finally the last syntax element's loaction will be wrong.
