### PR TITLE
Removing skulpt as a dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "webpack": "^1.13.1"
   },
   "devDependencies": {
-    "skulpt": "git+https://github.com/codecombat/skulpt.git",
     "chai": "^3.5.0",
     "mocha": "^3.0.2"
   }


### PR DESCRIPTION
It's not publicly available, and doesn't seem necessary for the build